### PR TITLE
Null check for memcopy to stop crash on load in midi.c

### DIFF
--- a/src/pc/sound/midi.c
+++ b/src/pc/sound/midi.c
@@ -61,6 +61,10 @@ static int mem_read(void *buf, int count, void *handle) {
   mstream_t *stream;
 
   stream = (mstream_t*)handle;
+  if (stream == NULL || stream->p == NULL) {
+      // Handle error appropriately
+      return FLUID_FAILED;  // Or some other error code
+  }
   memcpy(buf, stream->p, count);
   stream->p += count;
   return FLUID_OK;


### PR DESCRIPTION
There is a crash happening on load on Ubuntu:

```
Thread 1 "c1" received signal SIGSEGV, Segmentation fault.
0x56630dd0 in mem_read (buf=0xffffc3ac, count=8, handle=0x0)
    at src/pc/sound/midi.c:64
64	  memcpy(buf, stream->p, count);
(gdb) bt
#0  0x56630dd0 in mem_read (buf=0xffffc3ac, count=8, handle=0x0)
    at src/pc/sound/midi.c:64
#1  0xf7c6011d in ??? () at /lib/i386-linux-gnu/libfluidsynth.so.3
#2  0xf7c5de0a in ??? () at /lib/i386-linux-gnu/libfluidsynth.so.3
#3  0xf7c5e2c8 in ??? () at /lib/i386-linux-gnu/libfluidsynth.so.3
#4  0xf7c74172 in fluid_synth_sfload ()
    at /lib/i386-linux-gnu/libfluidsynth.so.3
#5  0x566316f3 in SwSepOpen (sep=0xdca10e48 "pQES", vab_id=0, count=1)
    at src/pc/sound/midi.c:232
#6  0x5660a671 in MidiOpenAndPlay (eid=0xdc8ed364) at src/midi.c:277
#7  0x5660a8a1 in MidiUpdate (en_ref=0xdc8ed364) at src/midi.c:323
#8  0x56609b24 in AudioUpdate () at src/audio.c:639
#9  0x5662ee20 in GLUpdate () at src/pc/gfx/gl.c:449
#10 0x5662630d in CoreLoop (lid=25) at src/main.c:291
#11 0x56625a44 in main () at src/main.c:101
```

I assume this is something to do with library version differences in libfluidsynth.so (just a guess).

Anyway adding a null check for the memcpy allows the game to run.